### PR TITLE
Fixed generate() replacing leaving [s, made empty optional parameters blank

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -65,8 +65,14 @@ class AltoRouter {
 			foreach($matches as $match) {
 				list($block, $pre, $type, $param, $optional) = $match;
 
+				if ($pre) {
+					$block = substr($block, 1);
+				}
+
 				if(isset($params[$param])) {
-					$url = str_replace(substr($block,1), $params[$param], $url);
+					$url = str_replace($block, $params[$param], $url);
+				} elseif ($optional) {
+					$url = str_replace($block, '', $url);
 				}
 			}
 			


### PR DESCRIPTION
``` php
'/page-[i:pageNum]';
$pageNum = 2;
```

was generating '/page-[1' instead of '/page-1'.

The $pre test fixes this.

---

``` php
'/[:catName]/[:pagination]?';
$catName = 'foobars';
```

was generating '/foobars/[:pagination]?' instead of '/foobars/'.

The $optional test fixes this (it doesn't remove the preceeding character, which might be desired)
