### PR TITLE
Strip the wrong way

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -13,7 +13,7 @@ class AltoRouter {
 	public function setBasePath($basePath) {
 		$this->basePath = $basePath;
 	}
-	
+
 	/**
 	 * Map a route to a target
 	 *
@@ -101,7 +101,7 @@ class AltoRouter {
 
 		// Strip query string (?a=b) from Request Url
 		if (($strpos = strpos($requestUrl, '?')) !== false) {
-			$requestUrl = substr($requestUrl, $strpos + 1);
+			$requestUrl = substr($requestUrl, 0, $strpos);
 		}
 
 		// set Request Method if it isn't passed as a parameter


### PR DESCRIPTION
Hi,

I was debugging my app and it seems that there is a problem when you "Strip query string (?a=b) from Request Url".

As it is now, it results with only the query string "?azerty=1234" so, obviously, no route match :)

I'm not sure of what you intended there, but if you think i'm right please, pull !
- niahoo
