### PR TITLE
AltoRouter::map() param $target should be optional.

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -19,7 +19,7 @@ class AltoRouter {
 	 *
 	 * @param string $method One of 4 HTTP Methods, or a pipe-separated list of multiple HTTP Methods (GET|POST|PUT|DELETE)
 	 * @param string $route The route regex, custom regex must start with an @. You can use multiple pre-set regex filters, like [i:id]
-	 * @param mixed $target The target where this route should point to. Can be anything.
+	 * @param mixed $target Optional target where this route should point to. Can be anything.
 	 * @param string $name Optional name of this route. Supply if you want to reverse route this url in your application.
 	 *
 	 */


### PR DESCRIPTION
Target is not necessary for a route to match up, and can be omitted
without issue.
