### PR TITLE
Trim trailing slash from base path.

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -11,7 +11,7 @@ class AltoRouter {
 	 * Useful if you are running your application from a subdirectory.
 	 */
 	public function setBasePath($basePath) {
-		$this->basePath = $basePath;
+		$this->basePath = rtrim($basePath, '/');
 	}
 
 	/**


### PR DESCRIPTION
If base path is something like '/' or '/alto/', with a mapped route like '/asdf', the generated route to match will be '//asdf' or '/alto//asdf'. This change prevents the base path trailing slash from conflicting mapped route.
