### PR TITLE
Fixed unit test with optional url parts in #22

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -197,7 +197,7 @@ class AltoRouter {
 				'h'  => '[0-9A-Fa-f]++',
 				'*'  => '.+?',
 				'**' => '.++',
-				''   => '[^/^.]++'
+				''   => '[^/\.]++'
 			);
 
 			foreach ($matches as $match) {


### PR DESCRIPTION
There is a unit test which is failing because the `.` character is not recognized as a valid part separator. This pull request addresses the issue and allows the following assertion to hold:

```
$this->router->map('GET', '/bar/[:controller]/[:action].[:type]?', 'bar_action', 'bar_route');
$this->router->match('/bar/test/do.json', 'GET')) ===  array(
'target' => 'bar_action',
'params' => array(
    'controller' => 'test',
    'action' => 'do',
    'type' => 'json'
),
'name' => 'bar_route'
)
```

None of the other unit tests were broken.
