### PR TITLE
Change autoload from file- to classmap- based for efficiency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
       "php": ">=5.3.0"
    },
    "autoload": {
-      "files": ["AltoRouter.php"]
+      "classmap": ["AltoRouter.php"]
    },
    "license" : "MIT"
 }


### PR DESCRIPTION
AltoRouter may not be needed for every request. Classmap autoloading allows the library to only be loaded when needed.
