### PR TITLE
Adding match example (copied from @tlongren's pull request #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ $router->map('POST','/users/[i:id]/[delete|update:action]', 'usersController#doA
 // reversed routing
 $router->generate('users_show', array('id' => 5));
 
+// Match the current request.
+$router->match();
+
 ```
 
 You can use the following limits on your named parameters. AltoRouter will create the correct regexes for you.


### PR DESCRIPTION
While there are differing opinions regarding the proposed link to the url rewriting gist, I don't see an issue with adding the router match example into README.md
