### PR TITLE
Calling the method addMatchTypes in the constructor

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -23,7 +23,7 @@ class AltoRouter {
 	  */
 	public function __construct( $routes = array(), $basePath = '', $matchTypes = array() ) {
 		$this->basePath = $basePath;
-		$this->matchTypes = array_merge($this->matchTypes, $matchTypes);
+		$this->addMatchTypes($matchTypes);
 
 		foreach( $routes as $route ) {
 			call_user_func_array(array($this,'map'),$route);
@@ -43,7 +43,7 @@ class AltoRouter {
 	 *
 	 * @param array $matchType The key is the name and the value is the regex.
 	 */
-	public function addMatchType($matchTypes) {
+	public function addMatchTypes($matchTypes) {
 		$this->matchTypes = array_merge($this->matchTypes, $matchTypes);
 	}
 

--- a/AltoRouterTest.php
+++ b/AltoRouterTest.php
@@ -268,7 +268,7 @@ class AltoRouterTest extends PHPUnit_Framework_TestCase
 
 	public function testMatchWithCustomNamedRegex()
 	{
-		$this->router->addMatchType(array('cId' => '[a-zA-Z]{2}[0-9](?:_[0-9]++)?'));
+		$this->router->addMatchTypes(array('cId' => '[a-zA-Z]{2}[0-9](?:_[0-9]++)?'));
 		$this->router->map('GET', '/bar/[cId:customId]', 'bar_action', 'bar_route');
 		
 		$this->assertEquals(array(


### PR DESCRIPTION
Calling the method addMatchTypes in the constructor instead of setting the property.

Changed method name to plural to match property and parameter.
