### PR TITLE
Common title match type

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -8,6 +8,7 @@ class AltoRouter {
 	protected $matchTypes = array(
 		'i'  => '[0-9]++',
 		'a'  => '[0-9A-Za-z]++',
+		't'  => '[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*',
 		'h'  => '[0-9A-Fa-f]++',
 		'*'  => '.+?',
 		'**' => '.++',


### PR DESCRIPTION
Since [a:title], as expected, matches only alphanumeric characters, but no dashes which are most commonly used as space alternative in titles, and [*:title] matches anything (Serbian latin characters šđžčć for an example), there is no out of the box type for properly matching titles. This type allows matching titles as it must start with an alphanumeric character, which can be followed by just one dash in which case it must be followed by at least one more alphanumeric character.

Allowed: mytitle, my-title
Not allowed: -my-title, my--title, my-title-

Usage: [t], [t:title]
