### PR TITLE
AutoDiscover basePath

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -22,6 +22,7 @@ class AltoRouter {
 	  * @param array $matchTypes
 	  */
 	public function __construct( $routes = array(), $basePath = '', $matchTypes = array() ) {
+		$basePath = ($basePath=='') ? $this->discoverBasePath() : $basePath ;
 		$this->setBasePath($basePath);
 		$this->addMatchTypes($matchTypes);
 
@@ -38,6 +39,15 @@ class AltoRouter {
 		$this->basePath = $basePath;
 	}
 
+	/**
+	 * auto discover the base path.
+	 * this relies on server SCRIPT_FILENAME and DOCUMENT_ROOT
+	 */
+	public function discoverBasePath() {
+		$basePath = str_replace ( $_SERVER["DOCUMENT_ROOT"], '', dirname($_SERVER["SCRIPT_FILENAME"]) );
+		return $basePath;
+	}
+	
 	/**
 	 * Add named match types. It uses array_merge so keys can be overwritten.
 	 *


### PR DESCRIPTION
AutoDiscover basePath by default so if it's not specified AltoRouter will discover it automatically. 

so basically you will no longer need to include 

``` php
$router->setBasePath('/AltoRouter/examples/basic');
```

This is safe since its backwards compatible, meaning that if someone specified the baseBath AltoRouter will still use that! 

I think its much better to try and discover the basePath since less configuration is needed to use AltoRouter and also this makes it more portable since if you move a script based on AltoRouter from FolderA to FolderB then it will work with no changes! 

This is of course not bullet proof since it relies on server SCRIPT_FILENAME and DOCUMENT_ROOT to discover the basePath and I am not sure these might differ in environments other than apache that i tried this.
