### PR TITLE
use specific php 5.5 patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: php
 php:
   - 5.3
   - 5.4
-  - 5.5.9
+  - 5.5.10
 
 script: phpunit --coverage-text ./


### PR DESCRIPTION
There are unicode problems with the current php 5.5 version on travis (5.5.11)
