### PR TITLE
Allow a method to be matched via a wildcard.

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -169,7 +169,7 @@ class AltoRouter {
 			list($method, $_route, $target, $name) = $handler;
 
 			// Allow matching of methods on a wildcard
-			if($methods === '*') {
+			if($method === '*') {
 				$method_match = true;
 			} else {
 				$methods = explode('|', $method);
@@ -182,7 +182,6 @@ class AltoRouter {
 						break;
 					}
 				}
-
 			}
 
 			// Method did not match, continue to next route.


### PR DESCRIPTION
In certain scenarios a method needs to be overwritten because of firewall or browser limitations.

Typical override solutions have been:
1) Use the _method parameter in a get or post.
2) use X-HTTP-Method-Override in the header.

This would allow a browser to do a post with an override to put, and allow a rest interface to do an update on an object.

This opens up the router to try and match on a limitless range.

Adding the ability to match on a wild card would allow you to catch all unknown methods
<code>
$router->map('*', '*', array('controller' => 'Pages', 'action' => 'pages_404'));
</code>
