### PR TITLE
Code cleanup

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -37,6 +37,7 @@ class AltoRouter {
 	 * @param array $routes
 	 * @return void
 	 * @author Koen Punt
+     * @throws Exception
 	 */
 	public function addRoutes($routes){
 		if(!is_array($routes) && !$routes instanceof Traversable) {
@@ -71,6 +72,7 @@ class AltoRouter {
 	 * @param string $route The route regex, custom regex must start with an @. You can use multiple pre-set regex filters, like [i:id]
 	 * @param mixed $target The target where this route should point to. Can be anything.
 	 * @param string $name Optional name of this route. Supply if you want to reverse route this url in your application.
+     * @throws Exception
 	 */
 	public function map($method, $route, $target, $name = null) {
 
@@ -96,6 +98,7 @@ class AltoRouter {
 	 * @param string $routeName The name of the route.
 	 * @param array @params Associative array of parameters to replace placeholders with.
 	 * @return string The URL of the route with named parameters in place.
+     * @throws Exception
 	 */
 	public function generate($routeName, array $params = array()) {
 

--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -51,6 +51,8 @@ class AltoRouter {
 	/**
 	 * Set the base path.
 	 * Useful if you are running your application from a subdirectory.
+     *
+     * @param $basePath
 	 */
 	public function setBasePath($basePath) {
 		$this->basePath = $basePath;
@@ -144,7 +146,6 @@ class AltoRouter {
 	public function match($requestUrl = null, $requestMethod = null) {
 
 		$params = array();
-		$match = false;
 
 		// set Request Url if it isn't passed as parameter
 		if($requestUrl === null) {
@@ -155,7 +156,7 @@ class AltoRouter {
 		$requestUrl = substr($requestUrl, strlen($this->basePath));
 
 		// Strip query string (?a=b) from Request Url
-		if (($strpos = strpos($requestUrl, '?')) !== false) {
+		if ($strpos = strpos($requestUrl, '?')) {
 			$requestUrl = substr($requestUrl, 0, $strpos);
 		}
 
@@ -202,14 +203,14 @@ class AltoRouter {
 				while (true) {
 					if (!isset($_route[$i])) {
 						break;
-					} elseif (false === $regex) {
+					} elseif (!$regex) {
 						$c = $n;
 						$regex = $c === '[' || $c === '(' || $c === '.';
-						if (false === $regex && false !== isset($_route[$i+1])) {
+						if (!$regex && isset($_route[$i+1])) {
 							$n = $_route[$i + 1];
 							$regex = $n === '?' || $n === '+' || $n === '*' || $n === '{';
 						}
-						if (false === $regex && $c !== '/' && (!isset($requestUrl[$j]) || $c !== $requestUrl[$j])) {
+						if (!$regex && $c !== '/' && (!isset($requestUrl[$j]) || $c !== $requestUrl[$j])) {
 							continue 2;
 						}
 						$j++;
@@ -221,7 +222,7 @@ class AltoRouter {
 				$match = preg_match($regex, $requestUrl, $params);
 			}
 
-			if(($match == true || $match > 0)) {
+			if($match) {
 
 				if($params) {
 					foreach($params as $key => $value) {
@@ -241,6 +242,9 @@ class AltoRouter {
 
 	/**
 	 * Compile the regex for a given route (EXPENSIVE)
+     *
+     * @param $route
+     * @return string
 	 */
 	private function compileRoute($route) {
 		if (preg_match_all('`(/|\.|)\[([^:\]]*+)(?::([^:\]]*+))?\](\?|)`', $route, $matches, PREG_SET_ORDER)) {

--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -35,7 +35,6 @@ class AltoRouter {
 	 *   );
 	 *
 	 * @param array $routes
-	 * @return void
 	 * @author Koen Punt
      * @throws Exception
 	 */


### PR DESCRIPTION
Cleaned up method docs, added @throws and some missing @params and @return. Removed unnecessary @return

cleaned up logic in the match method. (flase !== isset(.....)) is logically equivalent to "if false not equal to isset failing" other wise expressed as isset === true, or more cleanly just isset

cleaned up several if statements using backwards logic. false === $regex is not standards compliant in any standard. replaced with a standard !$regex or "if regex is false"