### PR TITLE
Add Flask-style URL converters

### DIFF
--- a/examples/urlconverter/.htaccess
+++ b/examples/urlconverter/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule . index.php [L]

--- a/examples/urlconverter/index.php
+++ b/examples/urlconverter/index.php
@@ -1,0 +1,81 @@
+<?php
+
+require '../../AltoRouter.php';
+
+class ListUrlConverter implements IUrlConverter {
+
+	function __construct($delimiter=',', $coerce='string') {
+		$this->delimiter = $delimiter;
+		$this->coerce = $coerce;
+	}
+
+	function getRegexp() {
+		return '[0-9a-zA-Z]+(' . $this->delimiter . '[0-9a-zA-Z]+)*';
+	}
+	
+	function getUrl($data) {
+		return join($this->delimiter, $data);
+	}
+
+	function getValue($url) {		
+		return array_map(function($value) {
+			settype($value, $this->coerce);
+			return $value;
+		}, explode($this->delimiter, $url));
+	}
+}
+
+class RandomRangeUrlConverter implements IUrlConverter {
+
+	function getRegexp() {
+		return '\d+\.\.\d+';
+	}
+	
+	function getUrl($data) {
+		return sprintf("%d..%d", $data[0], $data[1]);
+	}
+
+	function getValue($url) {
+		list($min, $max) = explode("..", $url);
+		return rand($min, $max);
+	}
+}
+
+$router = new AltoRouter();
+$router->setBasePath('/AltoRouter/examples/urlconverter');
+$router->addUrlConverters(
+	array(
+		'list' => new ListUrlConverter(',', 'int'),
+		'random_range' => new RandomRangeUrlConverter()
+	)
+);
+
+$router->map('GET', '/', 'Controller#home', 'home');
+$router->map('GET', '/list/[list:values]/', 'Controller#list', 'list');
+$router->map('GET', '/random/[random_range:value]/', 'Controller#random', 'random');
+
+// match current request
+$match = $router->match();
+?>
+
+
+
+<h1>URL converters</h1>
+
+<h3>Current request: </h3>
+<pre>
+	Route name: <?php var_dump($match['name']); ?>
+	Params (processed by URL converter): <?php var_dump($match['params']); ?>
+</pre>
+
+<h3>Try these requests: </h3>
+
+<?php
+	$link_home = $router->generate('home');
+	$link_foo_values = $router->generate('list', array('values' => array(1, 2, 3)));
+	$link_random_range = $router->generate('random', array('value' =>  array(0, 99)));
+?>
+
+<p><a href="<?php echo $link_home ?>">GET <?php echo $link_home ?></a></p>
+<p><a href="<?php echo $link_foo_values ?>">GET <?php echo $link_foo_values ?></a></p>
+<p><a href="<?php echo $link_random_range ?>">GET <?php echo $link_random_range ?></a></p>


### PR DESCRIPTION
URL converters — an easy way to parse and generate complex URLs inspired by python's Flask (and underlaying Werkzeug library) — http://werkzeug.pocoo.org/docs/0.10/routing/#custom-converters

Trivial example
-------------------
Imagine that you have URL `http://example.com/foo/1,2,3,4/` and matching route `/foo/[:value]/`
With regular match rule you you'll get `string "1,2,3,4"` and need to convert it to array manualy. Vice versa - to generate URL from array, you need to join its values first.

Now you can define URL converter

```php
class DelimitedStringConverter implements IUrlConverter {

    function __construct($delimiter=',') {
        $this->delimiter = $delimiter;
    }

    function getRegexp() {
        return '[0-9a-zA-Z]+(' . $this->delimiter . '[0-9a-zA-Z]+)*';
    }
    
    function getUrl($data) {
        return join($this->delimiter, $data);
    }

    function getValue($url) {
        return explode($this->delimiter, $url);
    }
}
```
Register it as `list` matching rule

```php
$router->addUrlConverters(array(
    'list' => new DelimitedStringConverter()
));
```

Map route `/foo/[list:value]/` — and you will get `array [1, 2, 3, 4]`
`$router->generate( 'foo', ['value' => [1, 2, 3, 4]] );` will produce `"/foo/1,2,3,4/"`


Real life example
---------------------
URL `http://example.com/filters/producer=LG,Lenovo;display_type=IPS;front_camera=2MP;cores=2,4/`
Maps to `"/filters/[filter_params:filters]/"`

```php
class FilterParamsConverter implements IUrlConverter {
    
    function __construct($keys_delimiter=';', $values_delimiter=',') {
        $this->keys_delimiter = $keys_delimiter;
        $this->values_delimiter = $values_delimiter;
    }
    
    function getRegexp() {
        return sprintf('[0-9a-zA-Z%s_=]+(%s[0-9a-zA-Z%s_=]+)*', 
            $this->keys_delimiter, 
            $this->values_delimiter, 
            $this->keys_delimiter);
    }

    /*
     *  in: ['producer' => ['LG', 'Lenovo'], 'display_type' => 'IPS', 'front_camera' => '2MP', 'cores' => ['2', '4']]
     * out: "cores=2,4;display_type=IPS;front_camera=2MP;producer=LG,Lenovo"
     */
    function getUrl($data) {
        $params = array();
        foreach($data as $key => $values) {
            if (!is_array($values)) {
                $values = array($values);
            } else {
                sort($values);
            }
            $params[] = sprintf("%s=%s", $key, join($this->values_delimiter, $values));    
        }
        sort($params);
        return join($this->keys_delimiter, $params);
    }
    
    /*
     *  in: "producer=LG,Lenovo;display_type=IPS;front_camera=2MP;cores=2,4"
     * out: ['producer' => ['LG', 'Lenovo'], 'display_type' => 'IPS', 'front_camera' => '2MP', 'cores' => ['2', '4']]
     */
    function getValue($url) {
        parse_str(str_replace($this->keys_delimiter, '&', $url), $result);
        foreach($result as $key => $values) {
            $result[$key] = array_unique(explode($this->values_delimiter, $values));
        }
        return $result; 
    }
}
```

`Filters` param populated with array

```
Array (
    [producer] => Array
        (
            [0] => LG
            [1] => Lenovo
        )

    [display_type] => Array
        (
            [0] => IPS
        )

    [front_camera] => Array
        (
            [0] => 2MP
        )

    [cores] => Array
        (
            [0] => 2
            [1] => 4
        )
)
```

Upon generation keys/values are sorted to unify URLs and avoid duplicating content with URLs differing only by params order.


Perfomance
---------------

There's no perfomance impact on routes w/o URL converter. Perfomance of routes with URL converter depends completely on getUrl(), getValue() implementation details. "Null" URL converter perfomance indistinguishable from regular route.

Why not just extend AltoRouter class?
------------------------------------------------

While changes are not so big (~40 LOC), they affects all main methods — map(), generate() and match(), so you basically need to override entire logic on every AltoRouter update.

Issues/TBD
--------------

1. Currently attempt to add URL converter to unnamed route throws an exception b.c. I'm using "route_name:param_name" as dict key. We can of course use route itself instead of route name, but it's a bit ugly :) 
Consider adding random/hashed names to unnamed routes upon map() call.

2. Converter cannot reject match. Flask have special ValidationError exception — you can throw it inside URL converter (for example if matched with regexp value is out of range) and router won't match this URL.