### PR TITLE
Use `stripos` to compare request method, instead of `explode` + `in_array`

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -189,18 +189,9 @@ class AltoRouter {
 		}
 
 		foreach($this->routes as $handler) {
-			list($method, $_route, $target, $name) = $handler;
+			list($methods, $_route, $target, $name) = $handler;
 
-			$methods = explode('|', $method);
-			$method_match = false;
-
-			// Check if request method matches. If not, abandon early. (CHEAP)
-			foreach($methods as $method) {
-				if (strcasecmp($requestMethod, $method) === 0) {
-					$method_match = true;
-					break;
-				}
-			}
+			$method_match = (stripos($methods, $requestMethod) !== false);
 
 			// Method did not match, continue to next route.
 			if(!$method_match) continue;


### PR DESCRIPTION
Basic benchmarking shows the following performance improvements when searching for a non-existing route (with 1000 defined routes).

_Benchmark set-up_
```php
$methods = array( 'GET', 'POST', 'GET|POST', 'PUT', 'PUT|POST' );
for( $i=0; $i < 1000; $i++ ) {
	$random_key = array_rand( $methods );
	$router->map( $methods[ $random_key ], '/not-important', function() {} );
}
```

_Apache Bench_
```sh
$ ab -n 1000  http://localhost/AltoRouter/non-existing-url
```

**Results**
With `strpos`: 6ms
With `explode + array check`: 8ms

Have yet to look using a tool like [Blackfire.io](https://blackfire.io/) but pretty sure it'll show an improvement as well. 

@koenpunt can you think of any reason why we should not do it like this?