### PR TITLE
Fix for optional parameters

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -207,20 +207,21 @@ class AltoRouter {
 				// No params in url, do string comparison
 				$match = strcmp($requestUrl, $route) === 0;
 			} else {
-				// Compare longest non-param string with url
-				// Fix for / or . for an optional parameter
+				//test for optional param
 				$optional = (substr($route, strpos ( $route, ']', $position )+1, 1) === '?');
-				$pref = (substr($route,$position, -1) === '.' || substr($route,$position, -1) === '/');
-				$pos = ($optional && $pref)?-1:0;
-                		if (strncmp($requestUrl, $route, $position) !== $pos) {
+				if ($optional) {
+                    			$signBefore = substr($route, $position - 1, 1);
+					// update optional if leading / or .
+					$optional = ($signBefore === '/' || $signBefore ==='.');
+				}
+				if ($optional) {
+		                	$strncmp = strncmp($requestUrl, $route, $position);
+					if ($strncmp !== -1 && $strncmp !== 0) {
+						continue;
+					}
+				} else if (strncmp($requestUrl, $route, $position) !== 0) {
 					continue;
 				}
-				/**
-				// Compare longest non-param string with url
-				if (strncmp($requestUrl, $route, $position) !== 0) {
-					continue;
-				}
-				**/
 				$regex = $this->compileRoute($route);
 				$match = preg_match($regex, $requestUrl, $params) === 1;
 			}

--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -208,9 +208,19 @@ class AltoRouter {
 				$match = strcmp($requestUrl, $route) === 0;
 			} else {
 				// Compare longest non-param string with url
+				// Fix for / or . for an optional parameter
+				$optional = (substr($route, strpos ( $route, ']', $position )+1, 1) === '?');
+				$pref = (substr($route,$position, -1) === '.' || substr($route,$position, -1) === '/');
+				$pos = ($optional && $pref)?-1:0;
+                		if (strncmp($requestUrl, $route, $position) !== $pos) {
+					continue;
+				}
+				/**
+				// Compare longest non-param string with url
 				if (strncmp($requestUrl, $route, $position) !== 0) {
 					continue;
 				}
+				**/
 				$regex = $this->compileRoute($route);
 				$match = preg_match($regex, $requestUrl, $params) === 1;
 			}

--- a/tests/AltoRouterTest.php
+++ b/tests/AltoRouterTest.php
@@ -271,7 +271,6 @@ class AltoRouterTest extends PHPUnit_Framework_TestCase
 			),
 			'name' => 'foo_route'
 		), $this->router->match('/foo/test/do?param=value', 'GET'));
-		
 	}
 
 	public function testMatchWithNonRegex() {
@@ -470,5 +469,22 @@ class AltoRouterTest extends PHPUnit_Framework_TestCase
 		), $this->router->match('/bar/some-path', 'GET'));
 		
 		$this->assertFalse($this->router->match('/﷽‎', 'GET'));
+	}
+	public function testMatchWithOneDynamicParam()
+	{
+		$this->router->map('GET', '/foo/[i:id]?', 'foo_action', 'foo_route');
+		$this->assertEquals(array(
+			'target' => 'foo_action',
+			'params' => array(
+				'id' => '666'
+			),
+			'name' => 'foo_route'
+		), $this->router->match('/foo/666', 'GET'));
+		
+		$this->assertEquals(array(
+			'target' => 'foo_action',
+			'params' => array(),
+			'name' => 'foo_route'
+		), $this->router->match('/foo', 'GET'));
 	}
 }


### PR DESCRIPTION
if first Paramter (found in Line 206) is optional strncmp should compare urllength without separator (cause preg_match works fine but strncmp returns -1)