### PR TITLE
Permit return of named routes

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -45,10 +45,16 @@ class AltoRouter {
 	/**
 	 * Retrieves all routes.
 	 * Useful if you want to process or display routes.
+	 *
+	 * @param bool $named
 	 * @return array All routes.
 	 */
-	public function getRoutes() {
-		return $this->routes;
+	public function getRoutes($named = FALSE) {
+		if($named === TRUE){
+			return $this->namedRoutes;
+		} else {
+			return $this->routes;
+		}
 	}
 
 	/**


### PR DESCRIPTION
By passing a boolean of TRUE to the getRoutes function you can retrieve a list of named routes which is handy if you want to quickly process your routes to build a sitemap vs iterating over the much larger routes.