### PR TITLE
Check requesturl is empty string

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -204,7 +204,7 @@ class AltoRouter
             $requestUrl = substr($requestUrl, 0, $strpos);
         }
 
-        $lastRequestUrlChar = $requestUrl[strlen($requestUrl)-1];
+        $lastRequestUrlChar = $requestUrl ? $requestUrl[strlen($requestUrl)-1] : '';
 
         // set Request Method if it isn't passed as a parameter
         if ($requestMethod === null) {


### PR DESCRIPTION
Check $request is empty string or not

Sometime I want to use match function for part of url ( that might be empty string ) so after I update this library I got error for `$requestUrl[strlen($requestUrl)-1]` say the offset -1 is not exist.

So I think it's necessary to check it