### PR TITLE
error computing lastRequestUrlChar

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -204,7 +204,7 @@ class AltoRouter
             $requestUrl = substr($requestUrl, 0, $strpos);
         }
 
-        $lastRequestUrlChar = $requestUrl ? $requestUrl[strlen($requestUrl)-1] : '';
+	$lastRequestUrlChar = $requestUrl === '' ? '' : $requestUrl[strlen($requestUrl)-1];
 
         // set Request Method if it isn't passed as a parameter
         if ($requestMethod === null) {


### PR DESCRIPTION
error in file AltoRouter.php:207, uninitialized string offset: -1, when the url is empty
fixed it with php 5.6 compatible patch