### PR TITLE
Update AltoRouter.php for php 8.4

### DIFF
--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -117,7 +117,7 @@ class AltoRouter
      * @param string $name Optional name of this route. Supply if you want to reverse route this url in your application.
      * @throws Exception
      */
-    public function map(string $method, string $route, $target, string|null $name = null)
+    public function map(string $method, string $route, $target, ?string $name = null)
     {
 
         $this->routes[] = [$method, $route, $target, $name];
@@ -184,7 +184,7 @@ class AltoRouter
      * @param string $requestMethod
      * @return array|boolean Array with route information on success, false on failure (no match).
      */
-    public function match(string|null $requestUrl = null, string|null $requestMethod = null)
+    public function match(?string $requestUrl = null, ?string $requestMethod = null)
     {
 
         $params = [];

--- a/AltoRouter.php
+++ b/AltoRouter.php
@@ -117,7 +117,7 @@ class AltoRouter
      * @param string $name Optional name of this route. Supply if you want to reverse route this url in your application.
      * @throws Exception
      */
-    public function map(string $method, string $route, $target, string $name = null)
+    public function map(string $method, string $route, $target, string|null $name = null)
     {
 
         $this->routes[] = [$method, $route, $target, $name];
@@ -184,7 +184,7 @@ class AltoRouter
      * @param string $requestMethod
      * @return array|boolean Array with route information on success, false on failure (no match).
      */
-    public function match(string $requestUrl = null, string $requestMethod = null)
+    public function match(string|null $requestUrl = null, string|null $requestMethod = null)
     {
 
         $params = [];


### PR DESCRIPTION
Fix for php8.4
AltoRouter::map(): Implicitly marking parameter $name as nullable is deprecated. AltoRouter::match(): Implicitly marking parameter $requestUrl as nullable is deprecated. AltoRouter::match(): Implicitly marking parameter $requestMethod as nullable is deprecated.